### PR TITLE
[OG Predicators PR] updates run_checks script to match new repo re-org

### DIFF
--- a/scripts/run_checks.sh
+++ b/scripts/run_checks.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 echo "Running autoformatting."
-yapf -i -r --style .style.yapf . && docformatter -i -r . && isort .
+yapf -i -r --style .style.yapf --exclude '**/third_party' predicators
+yapf -i -r --style .style.yapf scripts
+yapf -i -r --style .style.yapf tests
+docformatter -i -r . --exclude venv predicators/third_party
+isort .
 echo "Autoformatting complete."
 
 echo "Running type checking."


### PR DESCRIPTION
`scripts/run_checks.sh` was previously incorrect. This fixes the issue.