### PR TITLE
Adds openable object set

### DIFF
--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -124,6 +124,40 @@ PLACE_SURFACE_OBJECT_TYPES = {
     'pool_table', 'electric_refrigerator', 'clamshell', 'stand', 'cabinet',
     'room_floor'
 }
+OPENABLE_OBJECT_TYPES = {
+    'sack', 'storage_space', 'trap', 'turnbuckle', 'lock', 'trailer_truck',
+    'duplicator', 'slide_fastener', 'car', 'jug', 'percolator', 'window',
+    'coupling', 'package', 'collar', 'deep-freeze', 'walnut', 'pack', 'truck',
+    'nozzle', 'shoebox', 'journal', 'toolbox', 'grill', 'work', 'box', 'tin',
+    'wine_bottle', 'canned_food', 'choke', 'file', 'door', 'bag', 'facsimile',
+    'washer', 'envelope', 'basket', 'dredging_bucket', 'crock', 'spout',
+    'carabiner', 'album', 'screen', 'diary', 'drain', 'watchband', 'armoire',
+    'accessory', 'tent', 'dishwasher', 'dryer', 'vent', 'writing_board',
+    'personal_computer', 'scrapbook', 'bale', 'bin', 'coil', 'egg', 'reactor',
+    'belt', 'recreational_vehicle', 'canister', 'tie', 'notebook', 'backpack',
+    'stopcock', 'brassiere', 'pencil_box', 'tank', 'marinade', 'material',
+    'hinge', 'folder', 'wastepaper_basket', 'bucket', 'folding_chair',
+    'digital_computer', 'jaw', 'drawstring_bag', 'hamper', 'caddy',
+    'refrigerator', 'briefcase', 'shaker', 'hindrance', 'stapler', 'drawer',
+    'jar', 'binder', 'planner', 'gear', 'cupboard', 'gourd', 'windowpane',
+    'champagne', 'cooler', 'barrel', 'can', 'clamshell',
+    'electric_refrigerator', 'van', 'bird_feeder', 'kit', 'plate_glass',
+    'printer', 'mascara', 'velcro', 'pill', 'range_hood', 'packet', 'pen',
+    'knot', 'stove', 'marker', 'wallet', 'wardrobe', 'faucet', 'polish',
+    'cotter', 'bulldog_clip', 'connection', 'bundle', 'white_goods',
+    'office_furniture', 'vase', 'carryall', 'lipstick', 'sparkling_wine',
+    'kettle', 'highlighter', 'clamp', 'book', 'microwave', 'nutcracker',
+    'banana', 'pane', 'hole', 'coffeepot', 'bow', 'carton', 'sharpie',
+    'toilet', 'canopy', 'autoclave', 'pouch', 'drawstring', 'ventilation',
+    'lid', 'caster', 'buckle', 'mail', 'portable_computer', 'clog', 'capsule',
+    'clipboard', 'umbrella', 'packaging', 'laptop', 'drumstick', 'thing',
+    'mousetrap', 'shoulder_bag', 'latch', 'movable_barrier', 'hardback',
+    'chest_of_drawers', 'cage', 'novel', 'roaster', 'duffel_bag', 'diaper',
+    'ashcan', 'junction', 'mechanical_system', 'crusher', 'frame', 'shelter',
+    'chest', 'magazine', 'wicker', 'paperback_book', 'scanner', 'computer',
+    'dose', 'clasp', 'eyeliner', 'clothespin', 'hood', 'trademark', 'pincer',
+    'crate', 'cabinet', 'joint'
+}
 
 
 def get_aabb_volume(lo: Array, hi: Array) -> float:

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -7,7 +7,7 @@ from typing import List, Sequence, Set, Union, cast
 import numpy as np
 from numpy.random._generator import Generator
 
-from predicators.behavior_utils.behavior_utils import \
+from predicators.behavior_utils.behavior_utils import OPENABLE_OBJECT_TYPES, \
     PICK_PLACE_OBJECT_TYPES, PLACE_SURFACE_OBJECT_TYPES, check_nav_end_pose, \
     load_checkpoint_state
 from predicators.envs import get_or_create_env
@@ -3083,11 +3083,14 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
             assert len(option_arg_type_names) == 1
             open_obj_type_name = option_arg_type_names[0]
             open_obj_type = type_name_to_type[open_obj_type_name]
+            # We don't need an NSRT to open objects that are not
+            # openable.
+            if open_obj_type.name not in OPENABLE_OBJECT_TYPES:
+                continue
             open_obj = Variable("?obj", open_obj_type)
             # We don't need an NSRT to open the agent.
             if open_obj_type_name == "agent":
                 continue
-            # Open.
             parameters = [open_obj]
             option_vars = [open_obj]
             closed_predicate = _get_lifted_atom("closed", [open_obj])
@@ -3115,10 +3118,10 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
             close_obj_type_name = option_arg_type_names[0]
             close_obj_type = type_name_to_type[close_obj_type_name]
             close_obj = Variable("?obj", close_obj_type)
-            # We don't need an NSRT to close the agent.
-            if close_obj_type_name == "agent":
+            # We don't need an NSRT to close objects that are not
+            # openable.
+            if open_obj_type.name not in OPENABLE_OBJECT_TYPES:
                 continue
-            # Open.
             parameters = [close_obj]
             option_vars = [close_obj]
             preconditions = {

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -3120,7 +3120,7 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
             close_obj = Variable("?obj", close_obj_type)
             # We don't need an NSRT to close objects that are not
             # openable.
-            if open_obj_type.name not in OPENABLE_OBJECT_TYPES:
+            if close_obj_type.name not in OPENABLE_OBJECT_TYPES:
                 continue
             parameters = [close_obj]
             option_vars = [close_obj]


### PR DESCRIPTION
Adds an `openable` object set obtained from parsing `bddl`'s type hierarchy to `behavior_utils`. This allows us to not have to ground the `Open` and `Close` actions with all possible objects in a scene.

Tested on `locking_every_door` and `opening_presents`.