### PR TITLE
Open bug-fix, consistent typing, navigation sampler improvements.

### DIFF
--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -22,6 +22,17 @@ try:
 except (ImportError, ModuleNotFoundError) as e:  # pragma: no cover
     pass
 
+# NOTE: Each of these below constants obtained from parsing script in
+# LIS fork of the bddl repository. These sets might be incomplete, so
+# if you encounter an error while trying to solve a new BEHAVIOR task,
+# you might need to add to these.
+ALL_RELEVANT_OBJECT_TYPES = {
+    'breakfast_table', 'notebook', 'hardback', 'shelf', 'agent', 'room_floor',
+    'coffee_table', 'pop', 'bed', 'bucket', 'plate', 'hamburger', 'countertop',
+    'trash_can', 'backpack', 'toothbrush', 'shampoo', 'underwear', 'door',
+    'window', 'toothpaste', 'package', 'highlighter', 'swivel_chair',
+    'document', 'bottom_cabinet_no_top', 'folder', 'bottom_cabinet', 'top_cabinet'
+}
 PICK_PLACE_OBJECT_TYPES = {
     'mineral_water', 'oatmeal', 'blueberry', 'headset', 'jug', 'flank',
     'baseball', 'crab', 'dressing', 'cranberry', 'trout', 'kale', 'shoe',
@@ -128,7 +139,8 @@ PLACE_INTO_SURFACE_OBJECT_TYPES = {
     'casserole', 'bookshelf', 'teapot', 'dishwasher', 'deep-freeze', 'hamper',
     'bathtub', 'car', 'vase', 'jar', 'bin', 'mantel', 'stocking', 'ashcan',
     'electric_refrigerator', 'clamshell', 'backpack', 'sink', 'carton', 'dish',
-    'trash_can', 'bottom_cabinet_no_top', 'fridge', 'bottom_cabinet'
+    'trash_can', 'bottom_cabinet_no_top', 'fridge', 'bottom_cabinet',
+    'top_cabinet'
 }
 OPENABLE_OBJECT_TYPES = {
     'sack', 'storage_space', 'trap', 'turnbuckle', 'lock', 'trailer_truck',

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -31,7 +31,8 @@ ALL_RELEVANT_OBJECT_TYPES = {
     'coffee_table', 'pop', 'bed', 'bucket', 'plate', 'hamburger', 'countertop',
     'trash_can', 'backpack', 'toothbrush', 'shampoo', 'underwear', 'door',
     'window', 'toothpaste', 'package', 'highlighter', 'swivel_chair',
-    'document', 'bottom_cabinet_no_top', 'folder', 'bottom_cabinet', 'top_cabinet'
+    'document', 'bottom_cabinet_no_top', 'folder', 'bottom_cabinet',
+    'top_cabinet'
 }
 PICK_PLACE_OBJECT_TYPES = {
     'mineral_water', 'oatmeal', 'blueberry', 'headset', 'jug', 'flank',

--- a/predicators/behavior_utils/motion_planner_fns.py
+++ b/predicators/behavior_utils/motion_planner_fns.py
@@ -398,12 +398,12 @@ def make_place_plan(
     # passed in as an argument to this option, fail and return None
     if not (obj_in_hand is not None and obj_in_hand != obj):
         logging.info("Cannot place; either no object in hand or holding "
-                     "the object to be placed on top of!")
+                     "the object to be placed on top/inside of!")
         return None
 
     # if the object is not a urdf object, fail and return None
     if not isinstance(obj, URDFObject):
-        logging.info(f"PRIMITIVE: place {obj_in_hand.name} ontop "
+        logging.info(f"PRIMITIVE: place {obj_in_hand.name} ontop/inside "
                      f"{obj.name} fail, too far")
         return None
 
@@ -475,13 +475,13 @@ def make_place_plan(
 
     # If RRT planning fails, fail and return None
     if plan is None:
-        logging.info(f"PRIMITIVE: placeOnTop {obj.name} fail, failed "
+        logging.info(f"PRIMITIVE: placeOnTop/inside {obj.name} fail, failed "
                      f"to find plan to continuous params {place_rel_pos}")
         return None
 
     original_orientation = list(
         p.getEulerFromQuaternion(
             env.robots[0].parts["right_hand"].get_orientation()))
-    logging.info(f"PRIMITIVE: placeOnTop {obj.name} success! Plan found with "
-                 f"continuous params {place_rel_pos}.")
+    logging.info(f"PRIMITIVE: placeOnTop/inside {obj.name} success! Plan "
+                 f"found with continuous params {place_rel_pos}.")
     return plan, original_orientation

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -37,8 +37,8 @@ except (ImportError, ModuleNotFoundError) as e:
 from gym.spaces import Box
 
 from predicators import utils
-from predicators.behavior_utils.behavior_utils import ALL_RELEVANT_OBJECT_TYPES, \
-    load_checkpoint_state
+from predicators.behavior_utils.behavior_utils import \
+    ALL_RELEVANT_OBJECT_TYPES, load_checkpoint_state
 from predicators.behavior_utils.motion_planner_fns import make_dummy_plan, \
     make_grasp_plan, make_navigation_plan, make_place_plan
 from predicators.behavior_utils.option_fns import create_dummy_policy, \
@@ -244,11 +244,8 @@ class BehaviorEnv(BaseEnv):
         # Currently assumes that the goal is a single AND of
         # ground atoms (this is also assumed by the planner).
         goal = set()
-        try:
-            assert len(
-                self.igibson_behavior_env.task.ground_goal_state_options) == 1
-        except AssertionError:
-            import ipdb; ipdb.set_trace()
+        assert len(
+            self.igibson_behavior_env.task.ground_goal_state_options) == 1
         for head_expr in self.igibson_behavior_env.task.\
             ground_goal_state_options[0]:
             # BDDL expresses negative goals (such as 'not open').
@@ -341,9 +338,16 @@ class BehaviorEnv(BaseEnv):
 
     @property
     def types(self) -> Set[Type]:
-        for ig_obj in self._get_task_relevant_objects():
-        # for type_name in ALL_RELEVANT_OBJECT_TYPES:
-            type_name = ig_obj.category
+        # NOTE: The commented out for-loop line and the type_name line
+        # below are what we used to do before defining
+        # ALL_RELEVANT_OBJECT_TYPES. They are useful to comment back in
+        # when we want to debug a task by looking at the NSRTs (since
+        # putting these back in and commenting out the current for loop
+        # line will create only task-relevant typed NSRTs and not all
+        # NSRTs for all relevant object types).
+        # for ig_obj in self._get_task_relevant_objects():
+        for type_name in ALL_RELEVANT_OBJECT_TYPES:
+            # type_name = ig_obj.category
             if type_name in self._type_name_to_type:
                 continue
             # In the future, we may need other object attributes,
@@ -356,12 +360,6 @@ class BehaviorEnv(BaseEnv):
                 ],
             )
             self._type_name_to_type[type_name] = obj_type
-
-        # for t in self._type_name_to_type.values():
-        #     if t.name == "notebook":
-        #         import ipdb; ipdb.set_trace()
-
-        # import ipdb; ipdb.set_trace()
 
         return set(self._type_name_to_type.values())
 
@@ -446,13 +444,17 @@ class BehaviorEnv(BaseEnv):
     # lead to wrong mappings when we load a different scene
     def _ig_object_to_object(self, ig_obj: "ArticulatedObject") -> Object:
         type_name = ig_obj.category
-        try:
-            obj_type = self._type_name_to_type[type_name]
-        except KeyError:
-            for ig_obj in self._get_task_relevant_objects():
-                if ig_obj.category not in ALL_RELEVANT_OBJECT_TYPES:
-                    print(ig_obj.category)
-            import ipdb; ipdb.set_trace()
+        # NOTE: Since we don't necessarily have the full set of
+        # types we might need to solve a new domain, it is often
+        # useful to uncomment the below try-except block to
+        # print out types that need to be added to ALL_RELEVANT_OBJECT_TYPES.
+        # try:
+        obj_type = self._type_name_to_type[type_name]
+        # except KeyError:
+        #     for ig_obj in self._get_task_relevant_objects():
+        #         if ig_obj.category not in ALL_RELEVANT_OBJECT_TYPES:
+        #             print(ig_obj.category)
+        #     import ipdb; ipdb.set_trace()
         ig_obj_name = self._ig_object_name(ig_obj)
         return Object(ig_obj_name, obj_type)
 

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -706,8 +706,6 @@ def make_behavior_option(
         # Load the checkpoint associated with state.simulator_state
         # to make sure that we run low-level planning from the intended
         # state.
-        # if not state.allclose(
-        #             env.current_ig_state_to_state(save_state=False)):
         load_checkpoint_state(state, env)
 
         if memory.get("planner_result") is not None:

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -227,6 +227,11 @@ class BehaviorEnv(BaseEnv):
                         f"{CFG.seed}__{self.task_num}__" +
                         f"{self.task_instance_id}",
                         exist_ok=True)
+            # NOTE: We load_checkpoint_state here because there appears to
+            # be a subtle difference between calling the predicate classifiers
+            # on a particular state, and calling them after loading checkpoint
+            # on that particular state. Doing this resolves that discrepancy.
+            load_checkpoint_state(self.current_ig_state_to_state(), self)
             init_state = self.current_ig_state_to_state()
             goal = self._get_task_goal()
             task = Task(init_state, goal)
@@ -697,11 +702,14 @@ def make_behavior_option(
         assert len(igo) == 1
 
         # Load the checkpoint associated with state.simulator_state
-        # to make sure that we run RRT from the intended state.
+        # to make sure that we run low-level planning from the intended
+        # state.
+        # if not state.allclose(
+        #             env.current_ig_state_to_state(save_state=False)):
         load_checkpoint_state(state, env)
 
         if memory.get("planner_result") is not None:
-            # In this case, an rrt_plan has already been found for this
+            # In this case, a low-level plan has already been found for this
             # option (most likely, this will occur when executing a
             # series of options after having planned).
             return True

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -2823,8 +2823,8 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
         # The navigation nsrts are designed such that the target
         # obj is always last in the params list.
         obj_to_sample_near = objects[-1]
-        closeness_limit = 0.75
-        nearness_limit = 0.5
+        closeness_limit = 2.00
+        nearness_limit = 0.15
         distance = nearness_limit + (
             (closeness_limit - nearness_limit) * rng.random())
         yaw = rng.random() * (2 * np.pi) - np.pi

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -159,7 +159,6 @@ def _sesame_plan_with_astar(
         all_reachable_atoms = utils.get_reachable_atoms(
             nonempty_ground_nsrts, init_atoms)
         if check_dr_reachable and not task.goal.issubset(all_reachable_atoms):
-            import ipdb; ipdb.set_trace()
             raise PlanningFailure(f"Goal {task.goal} not dr-reachable")
         reachable_nsrts = [
             nsrt for nsrt in nonempty_ground_nsrts

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -159,6 +159,7 @@ def _sesame_plan_with_astar(
         all_reachable_atoms = utils.get_reachable_atoms(
             nonempty_ground_nsrts, init_atoms)
         if check_dr_reachable and not task.goal.issubset(all_reachable_atoms):
+            import ipdb; ipdb.set_trace()
             raise PlanningFailure(f"Goal {task.goal} not dr-reachable")
         reachable_nsrts = [
             nsrt for nsrt in nonempty_ground_nsrts


### PR DESCRIPTION
This PR does a few different things:
- Open bug-fix: previously, tasks like `opening-presents` and `opening-packages` were failing because certain objects were `ontop(floor)` in the initial state, but not ever after. We had to add a `load_checkpoint_state()` call whenever we create a new BEHAVIOR environment in order to resolve this.
- Consistent typing across tasks: previously, we used the relevant object set to generate types on a task-specific basis (i.e `sorting-book` and `opening-presents` would have entirely different types). However, we felt its better to have consistent types across tasks because then we can know the full type set and ensure there are no major issues (i.e, seeing a type at testing time that we never saw at training) during learning.
- Navigation sampler improvements: previously, the sampler attempted to find a collision-free point between 0.5 and 0.75 away from an object. This would frequently fail. Updated this to be between 0.15 and 2.00.