### PR TITLE
modifies placeOnTop to include a special-case for shelves

### DIFF
--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -414,6 +414,32 @@ def check_nav_end_pose(
     return valid_position
 
 
+def check_hand_end_pose(env: "BehaviorEnv", obj: Union["URDFObject",
+                                                       "RoomFloor"],
+                        pos_offset: Array) -> bool:
+    """Check that the robot's hand can reach pos_offset from the obj without
+    being in collision with anything.
+
+    If this is true, return True, else return False.
+    """
+    ret_bool = False
+    state = p.saveState()
+    obj_pos = obj.get_position()
+    hand_pos = (
+        pos_offset[0] + obj_pos[0],
+        pos_offset[1] + obj_pos[1],
+        pos_offset[2] + obj_pos[2],
+    )
+    env.robots[0].parts["right_hand"].set_position(hand_pos)
+    if not detect_robot_collision(env.robots[0]):
+        ret_bool = True
+
+    p.restoreState(state)
+    p.removeState(state)
+
+    return ret_bool
+
+
 def load_checkpoint_state(s: State,
                           env: "BehaviorEnv",
                           reset: bool = False) -> None:

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -2884,7 +2884,7 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
             "max_angle_with_z_axis": 0.17,
             "bimodal_stdev_fraction": 1e-6,
             "bimodal_mean_fraction": 1.0,
-            "max_sampling_attempts": 500,
+            "max_sampling_attempts": 50,
             "aabb_offset": 0.01,
         }
         aabb = get_aabb(objA.get_body_id())

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -9,8 +9,8 @@ from numpy.random._generator import Generator
 
 from predicators.behavior_utils.behavior_utils import OPENABLE_OBJECT_TYPES, \
     PICK_PLACE_OBJECT_TYPES, PLACE_INTO_SURFACE_OBJECT_TYPES, \
-    PLACE_ONTOP_SURFACE_OBJECT_TYPES, check_nav_end_pose, \
-    load_checkpoint_state
+    PLACE_ONTOP_SURFACE_OBJECT_TYPES, check_hand_end_pose, \
+    check_nav_end_pose, load_checkpoint_state
 from predicators.envs import get_or_create_env
 from predicators.envs.behavior import BehaviorEnv
 from predicators.envs.doors import DoorsEnv
@@ -2865,11 +2865,13 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
         return np.array([x_offset, y_offset, z_offset])
 
     # Place OnTop sampler definition.
+    MAX_PLACEONTOP_SAMPLES = 25
+
     def place_ontop_obj_pos_sampler(
             state: State, goal: Set[GroundAtom], rng: Generator,
             objects: Union["URDFObject", "RoomFloor"]) -> Array:
         """Sampler for placeOnTop option."""
-        del state, goal
+        # del state, goal
         assert rng is not None
         # objA is the object the robot is currently holding, and
         # objB is the surface that it must place onto.
@@ -2882,7 +2884,7 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
             "max_angle_with_z_axis": 0.17,
             "bimodal_stdev_fraction": 1e-6,
             "bimodal_mean_fraction": 1.0,
-            "max_sampling_attempts": 50,
+            "max_sampling_attempts": 500,
             "aabb_offset": 0.01,
         }
         aabb = get_aabb(objA.get_body_id())
@@ -2900,12 +2902,49 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
         )
 
         if sampling_results[0] is None or sampling_results[0][0] is None:
-            # If sampling fails, returns a random set of params
-            return np.array([
-                rng.uniform(-0.5, 0.5),
-                rng.uniform(-0.5, 0.5),
-                rng.uniform(0.3, 1.0)
-            ])
+            # If sampling fails, fall back onto custom-defined object-specific
+            # samplers
+            if "shelf" in objB.name:
+                # Get the current env for collision checking.
+                env = get_or_create_env("behavior")
+                assert isinstance(env, BehaviorEnv)
+                load_checkpoint_state(state, env)
+                objB_sampling_bounds = objB.bounding_box / 2
+                sample_params = np.array([
+                    rng.uniform(-objB_sampling_bounds[0],
+                                objB_sampling_bounds[0]),
+                    rng.uniform(-objB_sampling_bounds[1],
+                                objB_sampling_bounds[1]),
+                    rng.uniform(-objB_sampling_bounds[2] + 0.3,
+                                objB_sampling_bounds[1]) + 0.3
+                ])
+                logging.info("Sampling params for placeOnTop shelf...")
+                num_samples_tried = 0
+                while not check_hand_end_pose(env.igibson_behavior_env, objB,
+                                              sample_params):
+                    sample_params = np.array([
+                        rng.uniform(-objB_sampling_bounds[0],
+                                    objB_sampling_bounds[0]),
+                        rng.uniform(-objB_sampling_bounds[1],
+                                    objB_sampling_bounds[1]),
+                        rng.uniform(-objB_sampling_bounds[2] + 0.3,
+                                    objB_sampling_bounds[1]) + 0.3
+                    ])
+                    # NOTE: In many situations, it is impossible to find a good sample
+                    # no matter how many times we try. Thus, we break this loop after
+                    # a certain number of tries so the planner will backtrack.
+                    if num_samples_tried > MAX_PLACEONTOP_SAMPLES:
+                        break
+                    num_samples_tried += 1
+                return sample_params
+            else:
+                # If there's no object specific sampler, just return a
+                # random sample.
+                return np.array([
+                    rng.uniform(-0.5, 0.5),
+                    rng.uniform(-0.5, 0.5),
+                    rng.uniform(0.3, 1.0)
+                ])
 
         rnd_params = np.subtract(sampling_results[0][0], objB.get_position())
         return rnd_params

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -2871,7 +2871,7 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
             state: State, goal: Set[GroundAtom], rng: Generator,
             objects: Union["URDFObject", "RoomFloor"]) -> Array:
         """Sampler for placeOnTop option."""
-        # del state, goal
+        del goal
         assert rng is not None
         # objA is the object the robot is currently holding, and
         # objB is the surface that it must place onto.
@@ -2930,21 +2930,21 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
                         rng.uniform(-objB_sampling_bounds[2] + 0.3,
                                     objB_sampling_bounds[1]) + 0.3
                     ])
-                    # NOTE: In many situations, it is impossible to find a good sample
-                    # no matter how many times we try. Thus, we break this loop after
-                    # a certain number of tries so the planner will backtrack.
+                    # NOTE: In many situations, it is impossible to find a
+                    # good sample no matter how many times we try. Thus, we
+                    # break this loop after a certain number of tries so the
+                    # planner will backtrack.
                     if num_samples_tried > MAX_PLACEONTOP_SAMPLES:
                         break
                     num_samples_tried += 1
                 return sample_params
-            else:
-                # If there's no object specific sampler, just return a
-                # random sample.
-                return np.array([
-                    rng.uniform(-0.5, 0.5),
-                    rng.uniform(-0.5, 0.5),
-                    rng.uniform(0.3, 1.0)
-                ])
+            # If there's no object specific sampler, just return a
+            # random sample.
+            return np.array([
+                rng.uniform(-0.5, 0.5),
+                rng.uniform(-0.5, 0.5),
+                rng.uniform(0.3, 1.0)
+            ])
 
         rnd_params = np.subtract(sampling_results[0][0], objB.get_position())
         return rnd_params


### PR DESCRIPTION
Previously, if we called iGibson's sampling utils for placement and were unable to sample a position successfully, we'd simply fall back onto a random sampler. However, we now have some custom code that is specific to objects of category `shelf`. This enables us to solve `re-shelving_library_books` in `Rs_int` where we previously could not.

Full command to test:
```
python predicators/main.py --env behavior --approach oracle --behavior_mode simple --option_model_name oracle_behavior --num_train_tasks 0 --num_test_tasks 1 --behavior_scene_name Rs_int --behavior_task_name re-shelving_library_books --seed 1000 --offline_data_planning_timeout 500.0 --timeout 500.0 --behavior_option_model_eval True --plan_only_eval True --sesame_task_planner fdopt
```

NOTE: for this to work, be sure to pull the latest version of the LIS fork of iGibson (an important change to the `onTop` predicate was made).