### PR TITLE
Object-specific sampler for placeInside bucket

### DIFF
--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -2904,7 +2904,7 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
         if sampling_results[0] is None or sampling_results[0][0] is None:
             # If sampling fails, fall back onto custom-defined object-specific
             # samplers
-            if "shelf" in objB.name:
+            if objB.category == "shelf":
                 # Get the current env for collision checking.
                 env = get_or_create_env("behavior")
                 assert isinstance(env, BehaviorEnv)
@@ -2985,7 +2985,26 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
         )
 
         if sampling_results[0] is None or sampling_results[0][0] is None:
-            # If sampling fails, returns a random set of params
+            # If sampling fails, fall back onto custom-defined object-specific
+            # samplers
+            if objB.category == "bucket":
+                objB_sampling_bounds = objB.bounding_box / 2
+                # Since the bucket's hole is generally in the center,
+                # we want a very small sampling range around the
+                # object's position in the x and y directions (hence
+                # we divide the x and y bounds futher by 2).
+                sample_params = np.array([
+                    rng.uniform(-objB_sampling_bounds[0] / 2,
+                                objB_sampling_bounds[0] / 2),
+                    rng.uniform(-objB_sampling_bounds[1] / 2,
+                                objB_sampling_bounds[1] / 2),
+                    rng.uniform(objB_sampling_bounds[2] + 0.15,
+                                objB_sampling_bounds[2] + 0.5)
+                ])
+                return sample_params
+
+            # If there's no object specific sampler, just return a
+            # random sample.
             return np.array([
                 rng.uniform(-0.5, 0.5),
                 rng.uniform(-0.5, 0.5),


### PR DESCRIPTION
Previously, the `collecting_aluminum_cans` task would fail during refinement (especially in the `Ihlen_1_int` house). This PR introduces a new sampler for buckets that only samples reasonable locations to place at that are right above the bucket.

Command:
```
python predicators/main.py --env behavior --approach oracle --behavior_mode simple --option_model_name oracle_behavior --num_train_tasks 0 --num_test_tasks 1 --behavior_scene_name Benevolence_2_int --behavior_task_name collecting_aluminum_cans --seed 1000 --offline_data_planning_timeout 500.0 --timeout 500.0 --behavior_option_model_eval True --plan_only_eval True --sesame_task_planner fdopt
```

Notes:
- The sampler seems to fail consistently whenever the agent is far away from the bucket. There's probably some improvement we can make for this case by changing this and/or the navigation sampler.
- This PR also makes a slight change to the PlaceOnTopShelf sampler to use `obj.category` instead of `obj.name`.