### PR TITLE
Object-specific sampler for placeInside trash can

### DIFF
--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -3002,7 +3002,21 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
                                 objB_sampling_bounds[2] + 0.5)
                 ])
                 return sample_params
-
+            if objB.category == "trash_can":
+                objB_sampling_bounds = objB.bounding_box / 2
+                # Since the trash can's hole is generally in the center,
+                # we want a very small sampling range around the
+                # object's position in the x and y directions (hence
+                # we divide the x and y bounds futher by 4).
+                sample_params = np.array([
+                    rng.uniform(-objB_sampling_bounds[0] / 4,
+                                objB_sampling_bounds[0] / 4),
+                    rng.uniform(-objB_sampling_bounds[1] / 4,
+                                objB_sampling_bounds[1] / 4),
+                    rng.uniform(objB_sampling_bounds[2] + 0.05,
+                                objB_sampling_bounds[2] + 0.15)
+                ])
+                return sample_params
             # If there's no object specific sampler, just return a
             # random sample.
             return np.array([


### PR DESCRIPTION
Previously, the throwing_away_leftovers task would fail during refinement (especially in the Ihlen_1_int house). This PR introduces a new sampler for buckets that only samples reasonable locations to place at that are right above the bucket.

Command:
```
python predicators/main.py --env behavior --approach oracle --behavior_mode simple --option_model_name oracle_behavior --num_train_tasks 0 --num_test_tasks 1 --behavior_scene_name Wainscott_0_int --behavior_task_name throwing_away_leftovers --seed 1000 --offline_data_planning_timeout 500.0 --timeout 500.0 --behavior_option_model_eval True --plan_only_eval True --sesame_task_planner fdopt
```

Notes:
- This task is seemingly impossible in Pomaria_1_int because the trash can is closed and seemingly does not open...