### PR TITLE
No longer creates BDDL predicates involving the agent

### DIFF
--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -308,6 +308,11 @@ class BehaviorEnv(BaseEnv):
             # go to collect data and do NSRT learning.
             arity = self._bddl_predicate_arity(bddl_predicate)
             for type_combo in itertools.product(types_lst, repeat=arity):
+                # It is unnecessary to track whether the agent is ontop,
+                # inside or open things. Thus, we simply skip spawning
+                # these predicates.
+                if 'agent' in [t.name for t in type_combo]:
+                    continue
                 pred_name = self._create_type_combo_name(bddl_name, type_combo)
                 classifier = self._create_classifier_from_bddl(bddl_predicate)
                 pred = Predicate(pred_name, list(type_combo), classifier)


### PR DESCRIPTION
Previously, we would create predicates like `onTop(agent, floor)`. Not only are these pointless from a planning POV, but they also don't seem to work correctly, leading to issues with our expected_atoms check. This PR precludes such errors by never creating these predicates in the first place.