### PR TITLE
Fixes Bad Load Atoms

### DIFF
--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -12,10 +12,10 @@ from typing import Dict, List, Optional, Set
 import dill as pkl
 from gym.spaces import Box
 
-from predicators.behavior_utils import behavior_utils
 from predicators import utils
 from predicators.approaches.bilevel_planning_approach import \
     BilevelPlanningApproach
+from predicators.behavior_utils import behavior_utils
 from predicators.envs import get_or_create_env
 from predicators.envs.behavior import BehaviorEnv
 from predicators.nsrt_learning.nsrt_learning_main import learn_nsrts_from_data
@@ -108,11 +108,12 @@ class NSRTLearningApproach(BilevelPlanningApproach):
                 raise ValueError(f"Cannot load ground atoms: {dataset_fname}")
         else:
             # Apply predicates to data, producing a dataset of abstract states.
-            if CFG.env == "behavior":
+            if CFG.env == "behavior":  # pragma: no cover
                 env = get_or_create_env("behavior")
                 assert isinstance(env, BehaviorEnv)
-                ground_atom_dataset = behavior_utils.create_ground_atom_dataset_behavior(
-                    trajectories, self._get_current_predicates(), env)
+                ground_atom_dataset = \
+                    behavior_utils.create_ground_atom_dataset_behavior(
+                        trajectories, self._get_current_predicates(), env)
             else:
                 ground_atom_dataset = utils.create_ground_atom_dataset(
                     trajectories, self._get_current_predicates())

--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -12,9 +12,12 @@ from typing import Dict, List, Optional, Set
 import dill as pkl
 from gym.spaces import Box
 
+from predicators.behavior_utils import behavior_utils
 from predicators import utils
 from predicators.approaches.bilevel_planning_approach import \
     BilevelPlanningApproach
+from predicators.envs import get_or_create_env
+from predicators.envs.behavior import BehaviorEnv
 from predicators.nsrt_learning.nsrt_learning_main import learn_nsrts_from_data
 from predicators.planning import task_plan, task_plan_grounding
 from predicators.settings import CFG
@@ -105,8 +108,14 @@ class NSRTLearningApproach(BilevelPlanningApproach):
                 raise ValueError(f"Cannot load ground atoms: {dataset_fname}")
         else:
             # Apply predicates to data, producing a dataset of abstract states.
-            ground_atom_dataset = utils.create_ground_atom_dataset(
-                trajectories, self._get_current_predicates())
+            if CFG.env == "behavior":
+                env = get_or_create_env("behavior")
+                assert isinstance(env, BehaviorEnv)
+                ground_atom_dataset = behavior_utils.create_ground_atom_dataset_behavior(
+                    trajectories, self._get_current_predicates(), env)
+            else:
+                ground_atom_dataset = utils.create_ground_atom_dataset(
+                    trajectories, self._get_current_predicates())
             # Save ground atoms dataset to file. Note that a
             # GroundAtomTrajectory contains a normal LowLevelTrajectory and a
             # list of sets of GroundAtoms, so we only save the list of

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -5,10 +5,10 @@ from typing import List, Optional, Sequence, Tuple, Union
 import numpy as np
 import pybullet as p
 
-from predicators.utils import abstract
 from predicators.settings import CFG
-from predicators.structs import Array, State, Set
-from predicators.structs import GroundAtomTrajectory, LowLevelTrajectory, Predicate
+from predicators.structs import Array, GroundAtomTrajectory, \
+    LowLevelTrajectory, Predicate, Set, State
+from predicators.utils import abstract
 
 try:
     from igibson.envs.behavior_env import \
@@ -497,9 +497,10 @@ def load_checkpoint_state(s: State,
     env.igibson_behavior_env.step(
         np.zeros(env.igibson_behavior_env.action_space.shape))
 
+
 def create_ground_atom_dataset_behavior(
-        trajectories: Sequence[LowLevelTrajectory],
-        predicates: Set[Predicate], env: "BehaviorEnv") -> List[GroundAtomTrajectory]:
+        trajectories: Sequence[LowLevelTrajectory], predicates: Set[Predicate],
+        env: "BehaviorEnv") -> List[GroundAtomTrajectory]:  # pragma: no cover
     """Apply all predicates to all trajectories in the dataset."""
     ground_atom_dataset = []
     for traj in trajectories:

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -605,7 +605,11 @@ def _run_plan_with_option_model(
                                       _train_task_idx=task_idx), False
         if CFG.plan_only_eval:  # pragma: no cover
             assert isinstance(option_model, _BehaviorOptionModel)
-            next_state = option_model.load_state(last_traj[idx + 1])
+            # We need to load state into option model so predicate classifiers
+            # work when we run task.goal_holds(traj[-1]), otherwise
+            # classifiers will be ran on non-updated prior state.
+            option_model.load_state(last_traj[idx + 1])
+            next_state = last_traj[idx + 1]
         else:
             next_state, _ = option_model.get_next_state_and_num_actions(
                 state, option)


### PR DESCRIPTION
This PR fixes our `--load_atoms` flag for BEHVAIOR. The error was caused by not loading BEHAVIOR states when creating ground atoms dataset for learning. This led to failing a goal check assertion after loading a dataset before learning. We fix this by a creating ground atoms dataset function specific to BEHAVIOR which loads states before calling the predicate classifiers.