### PR TITLE
Run on  multiple BEHAVIOR tasks with "all" option

### DIFF
--- a/behavior.md
+++ b/behavior.md
@@ -11,8 +11,8 @@ git clone https://github.com/Learning-and-Intelligent-Systems/bddl.git
 * Currently, only the `oracle` approach is implemented to integrate with BEHAVIOR.
 * Note that you'll probably want to provide the command line argument `--timeout 1000` to prevent early stopping.
 * Set `--option_model_name oracle_behavior` to use the behavior option model and speed up planning by a significant factor.
-* Set `--behavior_task_name` to the name of the particular bddl task you'd like to run (e.g. `re-shelving_library_books`).
+* Set `--behavior_task_list` to the list of the particular bddl tasks you'd like to run (e.g. `"[re-shelving_library_books]"`).
 * Set `--behavior_scene_name` to the name of the house setting (e.g. `Pomaria_1_int`) you want to try running the particular task in. Note that not all tasks are available in all houses (e.g. `re-shelving_library_books` might only be available with `Pomaria_1_int`).
 * `--behavior_randomize_init_state` can be set to True if you want to generate multiple different initial states that correspond to the BDDL init conditions of a particular task.
 * If you'd like to see a visual of the agent planning in iGibson, set the command line argument `--behavior_mode simple`. If you want to run in headless mode without any visuals, leave the default (i.e `--behavior_mode headless`).
-* Example command: `python predicators/main.py --env behavior --approach oracle --seed 0 --timeout 1000 --sesame_max_samples_per_step 20 --behavior_mode simple --option_model_name oracle_behavior --num_train_tasks 2 --num_test_tasks 2 --behavior_randomize_init_state True --behavior_scene_name Pomaria_1_int --behavior_task_name re-shelving_library_books`.
+* Example command: `python predicators/main.py --env behavior --approach oracle --seed 0 --timeout 1000 --sesame_max_samples_per_step 20 --behavior_mode simple --option_model_name oracle_behavior --num_train_tasks 2 --num_test_tasks 2 --behavior_randomize_init_state True --behavior_scene_name Pomaria_1_int --behavior_task_list "[re-shelving_library_books]"`.

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -477,6 +477,7 @@ def load_checkpoint_state(s: State,
         # we reset the env.
         frame_count = env.igibson_behavior_env.simulator.frame_count
         env.set_igibson_behavior_env(
+            task_num=env.task_num,
             task_instance_id=new_task_num_task_instance_id[1],
             seed=env.task_num_task_instance_id_to_igibson_seed[
                 new_task_num_task_instance_id])

--- a/predicators/behavior_utils/behavior_utils.py
+++ b/predicators/behavior_utils/behavior_utils.py
@@ -486,10 +486,12 @@ def load_checkpoint_state(s: State,
         env.current_ig_state_to_state(
         )  # overwrite the old task_init checkpoint file!
         env.igibson_behavior_env.reset()
+    behavior_task_name = CFG.behavior_task_list[0] if len(
+        CFG.behavior_task_list) == 1 else "all"
     load_checkpoint(
         env.igibson_behavior_env.simulator,
         f"tmp_behavior_states/{CFG.behavior_scene_name}__" +
-        f"{CFG.behavior_task_name}__{CFG.num_train_tasks}__" +
+        f"{behavior_task_name}__{CFG.num_train_tasks}__" +
         f"{CFG.seed}__{env.task_num}__{env.task_instance_id}",
         int(s.simulator_state.split("-")[2]))
     np.random.seed(env.task_num_task_instance_id_to_igibson_seed[

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -69,7 +69,9 @@ class BehaviorEnv(BaseEnv):
                                                       List[str]] = json.load(f)
         # behavior_randomize_init_state will always be False in this
         # config_file because we are not using their scene samplers.
-        # We are loading pre-computed scenes.
+        # We are loading pre-computed scenes. Below we load either the
+        # pre-computed scene given by behavior_scene_name or randomly
+        # select a valid pre-computed scene.
         if len(CFG.behavior_task_list) != 0:
             assert CFG.behavior_scene_name == "all"
             rng = np.random.default_rng(0)

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -61,7 +61,7 @@ class BehaviorEnv(BaseEnv):
         if not _BEHAVIOR_IMPORTED:
             raise ModuleNotFoundError("BEHAVIOR is not installed.")
         # Loads dictionary mapping tasks to vaild scenes in BEHAVIOR.
-        if len(CFG.behavior_task_list) != 0:
+        if len(CFG.behavior_task_list) != 1:
             path_to_file = \
                 "predicators/behavior_utils/task_to_preselected_scenes.json"
             with open(path_to_file, 'rb') as f:
@@ -72,7 +72,7 @@ class BehaviorEnv(BaseEnv):
         # We are loading pre-computed scenes. Below we load either the
         # pre-computed scene given by behavior_scene_name or randomly
         # select a valid pre-computed scene.
-        if len(CFG.behavior_task_list) != 0:
+        if len(CFG.behavior_task_list) != 1:
             assert CFG.behavior_scene_name == "all"
             rng = np.random.default_rng(0)
             self._config_file = modify_config_file(
@@ -89,7 +89,7 @@ class BehaviorEnv(BaseEnv):
         self._rng = np.random.default_rng(self._seed)
         self.task_num = 0  # unique id to differentiate tasks
         self.task_instance_id = 0  # id used for scene
-        if len(CFG.behavior_task_list) != 0:
+        if len(CFG.behavior_task_list) != 1:
             self.task_list_indices = [
                 int(self._rng.integers(0, len(CFG.behavior_task_list)))
                 for _ in range(CFG.num_train_tasks + CFG.num_test_tasks)
@@ -264,7 +264,7 @@ class BehaviorEnv(BaseEnv):
                     self.task_instance_id = rng.integers(10, 20)
                 else:
                     self.task_instance_id = rng.integers(0, 10)
-                if len(CFG.behavior_task_list) != 0:
+                if len(CFG.behavior_task_list) != 1:
                     self.set_config_by_task_num(self.task_num)
                 self.set_igibson_behavior_env(
                     task_num=self.task_num,
@@ -473,7 +473,7 @@ class BehaviorEnv(BaseEnv):
         # iGibson env may fail and we need to keep trying until
         # ig_objs_bddl_scope doesn't contain any None's
         while True:
-            if len(CFG.behavior_task_list) != 0:
+            if len(CFG.behavior_task_list) != 1:
                 self.set_config_by_task_num(task_num)
             self.igibson_behavior_env = behavior_env.BehaviorEnv(
                 config_file=self._config_file,

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -174,16 +174,17 @@ class BehaviorEnv(BaseEnv):
                 )
                 self._options.add(option)
 
-    def set_config_by_index(self, task_index: int) -> None:
+    def set_config_by_task_num(self, task_num: int) -> None:
         """A method that changes BEHAVIORs config_file.
 
         Necessary when loading in an environment with different task or scene,
         which is used when running our BEHAVIOR all environments option.
         Note: This requires a behavior_task_list of tasks.
         """
+        task_index = self.task_list_indices[task_num]
         self._config_file = modify_config_file(
             os.path.join(igibson.root_path, CFG.behavior_config_file),
-            CFG.behavior_task_list[task_index], self.scene_list[task_index],
+            CFG.behavior_task_list[task_index], self.scene_list[task_num],
             False)
 
     def get_random_scene_for_task(self, behavior_task_name: str,
@@ -262,8 +263,7 @@ class BehaviorEnv(BaseEnv):
                 else:
                     self.task_instance_id = rng.integers(0, 10)
                 if CFG.behavior_task_name == "all":
-                    self.set_config_by_index(
-                        self.task_list_indices[self.task_num])
+                    self.set_config_by_task_num(self.task_num)
                 self.set_igibson_behavior_env(
                     task_num=self.task_num,
                     task_instance_id=self.task_instance_id,
@@ -470,7 +470,7 @@ class BehaviorEnv(BaseEnv):
         # ig_objs_bddl_scope doesn't contain any None's
         while True:
             if CFG.behavior_task_name == "all":
-                self.set_config_by_index(self.task_list_indices[task_num])
+                self.set_config_by_task_num(task_num)
             self.igibson_behavior_env = behavior_env.BehaviorEnv(
                 config_file=self._config_file,
                 mode=CFG.behavior_mode,

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -61,12 +61,12 @@ class BehaviorEnv(BaseEnv):
         if not _BEHAVIOR_IMPORTED:
             raise ModuleNotFoundError("BEHAVIOR is not installed.")
         # Loads dictionary mapping tasks to vaild scenes in BEHAVIOR.
-        self.task_to_preselected_scenes = None
         if CFG.behavior_task_name == "all":
             path_to_file = \
                 "predicators/behavior_utils/task_to_preselected_scenes.json"
             with open(path_to_file, 'rb') as f:
-                self.task_to_preselected_scenes = json.load(f)
+                self.task_to_preselected_scenes: Dict[str,
+                                                      List[str]] = json.load(f)
         # behavior_randomize_init_state will always be False in this
         # config_file because we are not using their scene samplers.
         # We are loading pre-computed scenes.
@@ -87,12 +87,11 @@ class BehaviorEnv(BaseEnv):
         self._rng = np.random.default_rng(self._seed)
         self.task_num = 0  # unique id to differentiate tasks
         self.task_instance_id = 0  # id used for scene
-        self.task_list_indices = None
         if CFG.behavior_task_name == "all":
-            self.task_list_indices = self._rng.integers(
-                0,
-                len(CFG.behavior_task_list),
-                size=CFG.num_train_tasks + CFG.num_test_tasks)
+            self.task_list_indices = [
+                int(self._rng.integers(0, len(CFG.behavior_task_list)))
+                for _ in range(CFG.num_train_tasks + CFG.num_test_tasks)
+            ]
             self.scene_list = [
                 self.get_random_scene_for_task(CFG.behavior_task_list[i],
                                                self._rng)

--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -3,6 +3,7 @@
 
 import functools
 import itertools
+import json
 import os
 from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
 
@@ -59,18 +60,46 @@ class BehaviorEnv(BaseEnv):
     def __init__(self) -> None:
         if not _BEHAVIOR_IMPORTED:
             raise ModuleNotFoundError("BEHAVIOR is not installed.")
+        # Loads dictionary mapping tasks to vaild scenes in BEHAVIOR.
+        self.task_to_preselected_scenes = None
+        if CFG.behavior_task_name == "all":
+            path_to_file = \
+                "predicators/behavior_utils/task_to_preselected_scenes.json"
+            with open(path_to_file, 'rb') as f:
+                self.task_to_preselected_scenes = json.load(f)
         # behavior_randomize_init_state will always be False in this
         # config_file because we are not using their scene samplers.
         # We are loading pre-computed scenes.
-        self._config_file = modify_config_file(
-            os.path.join(igibson.root_path, CFG.behavior_config_file),
-            CFG.behavior_task_name, CFG.behavior_scene_name, False)
+        if CFG.behavior_task_name == "all":
+            assert CFG.behavior_scene_name == "all"
+            rng = np.random.default_rng(0)
+            self._config_file = modify_config_file(
+                os.path.join(igibson.root_path, CFG.behavior_config_file),
+                CFG.behavior_task_list[0],
+                self.get_random_scene_for_task(CFG.behavior_task_list[0],
+                                               rng), False)
+        else:
+            self._config_file = modify_config_file(
+                os.path.join(igibson.root_path, CFG.behavior_config_file),
+                CFG.behavior_task_name, CFG.behavior_scene_name, False)
 
         super().__init__()  # To ensure self._seed is defined.
         self._rng = np.random.default_rng(self._seed)
         self.task_num = 0  # unique id to differentiate tasks
         self.task_instance_id = 0  # id used for scene
-        self.set_igibson_behavior_env(task_instance_id=self.task_instance_id,
+        self.task_list_indices = None
+        if CFG.behavior_task_name == "all":
+            self.task_list_indices = self._rng.integers(
+                0,
+                len(CFG.behavior_task_list),
+                size=CFG.num_train_tasks + CFG.num_test_tasks)
+            self.scene_list = [
+                self.get_random_scene_for_task(CFG.behavior_task_list[i],
+                                               self._rng)
+                for i in self.task_list_indices
+            ]
+        self.set_igibson_behavior_env(task_num=self.task_num,
+                                      task_instance_id=self.task_instance_id,
                                       seed=self._seed)
         self._type_name_to_type: Dict[str, Type] = {}
         # a map between task nums and the snapshot id for saving/loading
@@ -146,6 +175,23 @@ class BehaviorEnv(BaseEnv):
                 )
                 self._options.add(option)
 
+    def set_config_by_index(self, task_index: int) -> None:
+        """A method that changes BEHAVIORs config_file.
+
+        Necessary when loading in an environment with different task or scene,
+        which is used when running our BEHAVIOR all environments option.
+        Note: This requires a behavior_task_list of tasks.
+        """
+        self._config_file = modify_config_file(
+            os.path.join(igibson.root_path, CFG.behavior_config_file),
+            CFG.behavior_task_list[task_index], self.scene_list[task_index],
+            False)
+
+    def get_random_scene_for_task(self, behavior_task_name: str,
+                                  rng: Generator) -> str:
+        """A method that gets a valid random scene for a BEHAVIOR Task."""
+        return rng.choice(self.task_to_preselected_scenes[behavior_task_name])
+
     @classmethod
     def get_name(cls) -> str:
         return "behavior"
@@ -216,8 +262,13 @@ class BehaviorEnv(BaseEnv):
                     self.task_instance_id = rng.integers(10, 20)
                 else:
                     self.task_instance_id = rng.integers(0, 10)
+                if CFG.behavior_task_name == "all":
+                    self.set_config_by_index(
+                        self.task_list_indices[self.task_num])
                 self.set_igibson_behavior_env(
-                    task_instance_id=self.task_instance_id, seed=curr_env_seed)
+                    task_num=self.task_num,
+                    task_instance_id=self.task_instance_id,
+                    seed=curr_env_seed)
                 self.set_options()
             self.igibson_behavior_env.reset()
             self.task_num_task_instance_id_to_igibson_seed[(
@@ -409,7 +460,7 @@ class BehaviorEnv(BaseEnv):
     def _get_task_relevant_objects(self) -> List["ArticulatedObject"]:
         return list(self.igibson_behavior_env.task.object_scope.values())
 
-    def set_igibson_behavior_env(self, task_instance_id: int,
+    def set_igibson_behavior_env(self, task_num: int, task_instance_id: int,
                                  seed: int) -> None:
         """Sets/resets the igibson_behavior_env."""
         np.random.seed(seed)
@@ -419,6 +470,8 @@ class BehaviorEnv(BaseEnv):
         # iGibson env may fail and we need to keep trying until
         # ig_objs_bddl_scope doesn't contain any None's
         while True:
+            if CFG.behavior_task_name == "all":
+                self.set_config_by_index(self.task_list_indices[task_num])
             self.igibson_behavior_env = behavior_env.BehaviorEnv(
                 config_file=self._config_file,
                 mode=CFG.behavior_mode,

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -402,7 +402,8 @@ def _save_test_results(results: Metrics,
     logging.info(f"Tasks solved: {num_solved} / {num_total}")
     logging.info(f"Average time for successes: {avg_suc_time:.5f} seconds")
     if CFG.env == "behavior":  # pragma: no cover
-        behavior_task_name = CFG.behavior_task_list[0] if len(CFG.behavior_task_list) == 1 else "all"
+        behavior_task_name = CFG.behavior_task_list[0] if len(
+            CFG.behavior_task_list) == 1 else "all"
         outfile = (f"{CFG.results_dir}/{utils.get_config_path_str()}__"
                    f"{online_learning_cycle}__{behavior_task_name}__"
                    f"{CFG.behavior_scene_name}.pkl")

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -402,8 +402,9 @@ def _save_test_results(results: Metrics,
     logging.info(f"Tasks solved: {num_solved} / {num_total}")
     logging.info(f"Average time for successes: {avg_suc_time:.5f} seconds")
     if CFG.env == "behavior":  # pragma: no cover
+        behavior_task_name = CFG.behavior_task_list[0] if len(CFG.behavior_task_list) == 1 else "all"
         outfile = (f"{CFG.results_dir}/{utils.get_config_path_str()}__"
-                   f"{online_learning_cycle}__{CFG.behavior_task_name}__"
+                   f"{online_learning_cycle}__{behavior_task_name}__"
                    f"{CFG.behavior_scene_name}.pkl")
     else:
         outfile = (f"{CFG.results_dir}/{utils.get_config_path_str()}__"

--- a/predicators/nsrt_learning/nsrt_learning_main.py
+++ b/predicators/nsrt_learning/nsrt_learning_main.py
@@ -45,7 +45,7 @@ def learn_nsrts_from_data(
     smallest_pnads = None
     smallest_pnad_complexity = float('inf')
     rng = np.random.default_rng(CFG.seed)
-    for _ in range(CFG.data_orderings_to_search):
+    for order_i in range(CFG.data_orderings_to_search):
         # Step 0: Shuffle dataset to learn from.
         if CFG.data_orderings_to_search > 1:
             random_data_indices = sorted(
@@ -55,6 +55,8 @@ def learn_nsrts_from_data(
             ground_atom_dataset = [
                 ground_atom_dataset[i] for i in random_data_indices
             ]
+            logging.info(f"Learning NSRTs on Ordering {order_i}/"
+                         f"{CFG.data_orderings_to_search}")
         # STEP 1: Segment each trajectory in the dataset based on changes in
         #         either predicates or options. If we are doing option learning,
         #         then the data will not contain options, so this segmenting

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -115,12 +115,11 @@ class GlobalSettings:
     behavior_mode = "headless"  # headless, pbgui, iggui
     behavior_action_timestep = 1.0 / 10.0
     behavior_physics_timestep = 1.0 / 120.0
-    behavior_task_name = "re-shelving_library_books"
+    behavior_task_list = ["re-shelving_library_books"]
     behavior_scene_name = "Pomaria_1_int"
     behavior_randomize_init_state = True
     behavior_option_model_eval = False
     behavior_option_model_rrt = False
-    behavior_task_list = None
 
     # general pybullet parameters
     pybullet_use_gui = False  # must be True to make videos

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -120,6 +120,7 @@ class GlobalSettings:
     behavior_randomize_init_state = True
     behavior_option_model_eval = False
     behavior_option_model_rrt = False
+    behavior_task_list = None
 
     # general pybullet parameters
     pybullet_use_gui = False  # must be True to make videos

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -1867,8 +1867,10 @@ def create_dataset_filename_str(
         suffix_str += "__ground_atoms"
     suffix_str += ".data"
     if CFG.env == "behavior":  # pragma: no cover
+        behavior_task_name = CFG.behavior_task_list[0] if len(
+            CFG.behavior_task_list) == 1 else "all"
         dataset_fname_template = (
-            f"{CFG.env}__{CFG.behavior_scene_name}__{CFG.behavior_task_name}" +
+            f"{CFG.env}__{CFG.behavior_scene_name}__{behavior_task_name}" +
             f"__{CFG.offline_data_method}__{CFG.demonstrator}__"
             f"{regex}__{CFG.included_options}__{CFG.seed}" + suffix_str)
     else:

--- a/scripts/local/run_behavior_tests.py
+++ b/scripts/local/run_behavior_tests.py
@@ -49,7 +49,7 @@ def _run_behavior_pickplaceopen_tests() -> None:
                             "--num_train_tasks 1 "
                             f"--num_test_tasks {NUM_TEST} "
                             f"--behavior_scene_name {scene} "
-                            f"--behavior_task_name {task} "
+                            f"--behavior_task_list \"[{task}]\" "
                             f"--seed {SEED} "
                             f"--offline_data_planning_timeout {TIMEOUT} "
                             f"--timeout {TIMEOUT} "

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -182,7 +182,7 @@ EXTRA_ARGS_ORACLE_APPROACH["behavior_tasks"] = [
         "num_train_tasks": 1,
         "num_test_tasks": 1,
         "behavior_scene_name": "Pomaria_1_int",
-        "behavior_task_name": "sorting_books",
+        "behavior_task_list": "\"[sorting_books]\"",
         "offline_data_planning_timeout": 30000.0,
     },
 ]


### PR DESCRIPTION
This PR allows us to run on multiple tasks in BEHAVIOR. For example this command:

`python predicators/main.py --env behavior --approach oracle --behavior_mode simple --option_model_name oracle_behavior --num_train_tasks 0 --num_test_tasks 5 --behavior_task_list "[opening_presents,opening_packages]" --behavior_scene_name all --seed 0 --offline_data_planning_timeout 100.0 --timeout 100.0 --behavior_option_model_eval True --plan_only_eval True`

This will run oracle on both opening_presents and opening_packages, sampled randomly with random scenes.

Note: This will currently save all results to to the same files with behavior_task_name="all" and behavior_scene_name="all".