### PR TITLE
Supercloud load atoms

### DIFF
--- a/scripts/cluster_utils.py
+++ b/scripts/cluster_utils.py
@@ -128,8 +128,7 @@ def get_cmds_to_prep_repo(branch: str, transfer_local_data: bool) -> List[str]:
     ]
     if not transfer_local_data:
         ret_cmds.append(
-            "rm -f results/* logs/* saved_approaches/* saved_datasets/*"
-        )
+            "rm -f results/* logs/* saved_approaches/* saved_datasets/*")
 
     return ret_cmds
 

--- a/scripts/cluster_utils.py
+++ b/scripts/cluster_utils.py
@@ -128,7 +128,7 @@ def get_cmds_to_prep_repo(branch: str, transfer_local_data: bool) -> List[str]:
             "rm -f results/* logs/* saved_approaches/* saved_datasets/*, tmp_behavior_states/*"
         )
 
-    return
+    return ret_cmds
 
 
 def run_cmds_on_machine(

--- a/scripts/cluster_utils.py
+++ b/scripts/cluster_utils.py
@@ -113,18 +113,22 @@ def generate_run_configs(config_filename: str,
                                                   seed)
 
 
-def get_cmds_to_prep_repo(branch: str) -> List[str]:
+def get_cmds_to_prep_repo(branch: str, transfer_local_data: bool) -> List[str]:
     """Get the commands that should be run while already in the repository but
     before launching the experiments."""
-    return [
+    ret_cmds = [
         "mkdir -p logs",
         "git stash",
         "git fetch --all",
         f"git checkout {branch}",
         "git pull",
-        # Remove old results.
-        "rm -f results/* logs/* saved_approaches/* saved_datasets/*, tmp_behavior_states/*",
     ]
+    if not transfer_local_data:
+        ret_cmds.append(
+            "rm -f results/* logs/* saved_approaches/* saved_datasets/*, tmp_behavior_states/*"
+        )
+
+    return
 
 
 def run_cmds_on_machine(

--- a/scripts/cluster_utils.py
+++ b/scripts/cluster_utils.py
@@ -123,7 +123,7 @@ def get_cmds_to_prep_repo(branch: str) -> List[str]:
         f"git checkout {branch}",
         "git pull",
         # Remove old results.
-        "rm -f results/* logs/* saved_approaches/* saved_datasets/*",
+        "rm -f results/* logs/* saved_approaches/* saved_datasets/*, tmp_behavior_states/*",
     ]
 
 
@@ -140,10 +140,17 @@ def run_cmds_on_machine(
         ssh_cmd += f" -i {ssh_key}"
     server_cmd_str = "\n".join(cmds + ["exit"])
     final_cmd = f"{ssh_cmd} << EOF\n{server_cmd_str}\nEOF"
-    response = subprocess.run(final_cmd,
+    run_command_with_subprocess(final_cmd, allowed_return_codes)
+
+
+def run_command_with_subprocess(
+    cmd: str, allowed_return_codes: Tuple[int, ...] = (0, )) -> None:
+    """Run a command string with subprocess.run and raise an error if the
+    return code is not as expected."""
+    response = subprocess.run(cmd,
                               stdout=subprocess.DEVNULL,
                               stderr=subprocess.STDOUT,
                               shell=True,
                               check=False)
     if response.returncode not in allowed_return_codes:
-        raise RuntimeError(f"Command failed: {final_cmd}")
+        raise RuntimeError(f"Command failed: {cmd}")

--- a/scripts/cluster_utils.py
+++ b/scripts/cluster_utils.py
@@ -125,7 +125,7 @@ def get_cmds_to_prep_repo(branch: str, transfer_local_data: bool) -> List[str]:
     ]
     if not transfer_local_data:
         ret_cmds.append(
-            "rm -f results/* logs/* saved_approaches/* saved_datasets/*, tmp_behavior_states/*"
+            "rm -f results/* logs/* saved_approaches/* saved_datasets/*"
         )
 
     return ret_cmds
@@ -151,6 +151,7 @@ def run_command_with_subprocess(
     cmd: str, allowed_return_codes: Tuple[int, ...] = (0, )) -> None:
     """Run a command string with subprocess.run and raise an error if the
     return code is not as expected."""
+    print(cmd)
     response = subprocess.run(cmd,
                               stdout=subprocess.DEVNULL,
                               stderr=subprocess.STDOUT,

--- a/scripts/configs/behavior_example.yaml
+++ b/scripts/configs/behavior_example.yaml
@@ -2,12 +2,12 @@
 ---
 APPROACHES:
   my-oracle:  # used in constructing the experiment ID
-    NAME: "oracle"
-    FLAGS:
-      offline_data_planning_timeout: 500.0
-      timeout: 500.0
-      plan_only_eval: True
-      sesame_task_planner: fdopt
+    # NAME: "oracle"
+    # FLAGS:
+    #   offline_data_planning_timeout: 500.0
+    #   timeout: 500.0
+    #   plan_only_eval: True
+    #   sesame_task_planner: fdopt
   backchaining:
     NAME: "nsrt_learning"
     FLAGS:
@@ -24,7 +24,9 @@ ENVS:
       behavior_scene_name: Pomaria_2_int
       behavior_task_list: "[opening_packages]"
       behavior_option_model_eval: True
-ARGS: {}
+ARGS:
+  - "load_atoms"
+  - "load_data"
 FLAGS:  # general flags
   num_train_tasks: 10
   num_test_tasks: 10

--- a/scripts/configs/behavior_example.yaml
+++ b/scripts/configs/behavior_example.yaml
@@ -1,13 +1,14 @@
+
 # An example configuration file.
 ---
 APPROACHES:
-  # my-oracle:  # used in constructing the experiment ID
-  #   NAME: "oracle"
-  #   FLAGS:
-  #     offline_data_planning_timeout: 500.0
-  #     timeout: 500.0
-  #     plan_only_eval: True
-  #     sesame_task_planner: fdopt
+  my-oracle:  # used in constructing the experiment ID
+    NAME: "oracle"
+    FLAGS:
+      offline_data_planning_timeout: 500.0
+      timeout: 500.0
+      plan_only_eval: True
+      sesame_task_planner: fdopt
   backchaining:
     NAME: "nsrt_learning"
     FLAGS:
@@ -24,9 +25,7 @@ ENVS:
       behavior_scene_name: Pomaria_2_int
       behavior_task_list: "[opening_packages]"
       behavior_option_model_eval: True
-ARGS:
-  - "load_atoms"
-  - "load_data"
+ARGS: {}
 FLAGS:  # general flags
   num_train_tasks: 10
   num_test_tasks: 10

--- a/scripts/configs/behavior_example.yaml
+++ b/scripts/configs/behavior_example.yaml
@@ -1,4 +1,3 @@
-
 # An example configuration file.
 ---
 APPROACHES:

--- a/scripts/configs/behavior_example.yaml
+++ b/scripts/configs/behavior_example.yaml
@@ -1,13 +1,13 @@
 # An example configuration file.
 ---
 APPROACHES:
-  my-oracle:  # used in constructing the experiment ID
-    # NAME: "oracle"
-    # FLAGS:
-    #   offline_data_planning_timeout: 500.0
-    #   timeout: 500.0
-    #   plan_only_eval: True
-    #   sesame_task_planner: fdopt
+  # my-oracle:  # used in constructing the experiment ID
+  #   NAME: "oracle"
+  #   FLAGS:
+  #     offline_data_planning_timeout: 500.0
+  #     timeout: 500.0
+  #     plan_only_eval: True
+  #     sesame_task_planner: fdopt
   backchaining:
     NAME: "nsrt_learning"
     FLAGS:

--- a/scripts/local/launch.py
+++ b/scripts/local/launch.py
@@ -22,7 +22,7 @@ def _main() -> None:
     parser.add_argument("--branch", type=str, default=DEFAULT_BRANCH)
     args = parser.parse_args()
     # Prepare the repo.
-    for cmd in get_cmds_to_prep_repo(args.branch):
+    for cmd in get_cmds_to_prep_repo(args.branch, False):
         subprocess.run(cmd, shell=True, check=False)
     # Create the run commands.
     cmds = []

--- a/scripts/openstack/launch.py
+++ b/scripts/openstack/launch.py
@@ -56,7 +56,7 @@ def _launch_experiment(cmd: str, machine: str, logfile: str, ssh_key: str,
     # Enter the repo.
     server_cmds = ["cd ~/predicators"]
     # Prepare the repo.
-    server_cmds.extend(get_cmds_to_prep_repo(branch))
+    server_cmds.extend(get_cmds_to_prep_repo(branch, False))
     # Run the main command.
     server_cmds.append(f"{cmd} &> {logfile} &")
     run_cmds_on_machine(server_cmds, "ubuntu", machine, ssh_key=ssh_key)

--- a/scripts/supercloud/launch.py
+++ b/scripts/supercloud/launch.py
@@ -14,7 +14,6 @@ The default branch can be overridden with the --branch flag.
 """
 
 import argparse
-import sys
 
 from scripts.cluster_utils import DEFAULT_BRANCH, SUPERCLOUD_IP, \
     BatchSeedRunConfig, config_to_cmd_flags, config_to_logfile, \

--- a/scripts/supercloud/launch.py
+++ b/scripts/supercloud/launch.py
@@ -54,13 +54,13 @@ def _launch_from_local(branch: str, user: str, transfer_local_data: bool,
         # Enter the repo and wipe saved data, approaches and behavior states.
         server_cmds = ["predicate_behavior"]
         server_cmds += [
-            "rm -f results/* logs/* saved_approaches/* saved_datasets/*, " +
-            "tmp_behavior_states/*"
+            "rm -f results/* logs/* saved_approaches/* saved_datasets/*"
         ]
+        server_cmds += ["rm -rf tmp_behavior_states/*"]
         run_cmds_on_machine(server_cmds, user, SUPERCLOUD_IP)
         server_cmds = []
         for folder in [
-                "saved_approaches", "saved_datasets" "tmp_behavior_states"
+                "saved_approaches", "saved_datasets", "tmp_behavior_states"
         ]:
             cmd = "rsync -avzhe ssh " + \
               f"{folder}/* {user}@{SUPERCLOUD_IP}:{supercloud_dir}/{folder}"

--- a/scripts/supercloud/launch.py
+++ b/scripts/supercloud/launch.py
@@ -4,6 +4,12 @@ Usage example:
 
     python scripts/supercloud/launch.py --config example_basic.yaml --user tslvr
 
+Usage example with supercloud dir:
+
+    python scripts/supercloud/launch.py --config example_basic.yaml \
+        --user njk --transfer_local_data \
+        --supercloud_dir ~/GitHub/research/predicators_behavior
+
 The default branch can be overridden with the --branch flag.
 """
 

--- a/scripts/supercloud/launch.py
+++ b/scripts/supercloud/launch.py
@@ -72,7 +72,7 @@ def _launch_from_local(branch: str, user: str, transfer_local_data: bool,
     # Enter the repo.
     server_cmds = ["predicate_behavior"]
     # Prepare the repo.
-    server_cmds.extend(get_cmds_to_prep_repo(branch))
+    server_cmds.extend(get_cmds_to_prep_repo(branch, transfer_local_data))
     # Finally, run this file again, but with the on_supercloud flag.
     server_cmds.append(f"python {str_args} --on_supercloud")
     run_cmds_on_machine(server_cmds, user, SUPERCLOUD_IP)

--- a/scripts/supercloud/launch.py
+++ b/scripts/supercloud/launch.py
@@ -60,7 +60,7 @@ def _launch_from_local(branch: str, user: str, transfer_local_data: bool,
         run_cmds_on_machine(server_cmds, user, SUPERCLOUD_IP)
         server_cmds = []
         for folder in [
-                "saved_approaches", "saved_datasets", "tmp_behavior_states"
+                "saved_approaches", "saved_datasets" "tmp_behavior_states"
         ]:
             cmd = "rsync -avzhe ssh " + \
               f"{folder}/* {user}@{SUPERCLOUD_IP}:{supercloud_dir}/{folder}"

--- a/scripts/supercloud/launch.py
+++ b/scripts/supercloud/launch.py
@@ -67,7 +67,10 @@ def _launch_from_local(branch: str, user: str, transfer_local_data: bool,
         server_cmd_str = "\n".join(server_cmds + ["exit"])
         run_command_with_subprocess(server_cmd_str)
 
-    str_args = " ".join(["scripts/supercloud/launch.py", f"--config {config_file}", f"--user {user}"])
+    str_args = " ".join([
+        "scripts/supercloud/launch.py", f"--config {config_file}",
+        f"--user {user}"
+    ])
     # Enter the repo.
     server_cmds = ["predicate_behavior"]
     # Prepare the repo.

--- a/scripts/supercloud/launch.py
+++ b/scripts/supercloud/launch.py
@@ -38,7 +38,7 @@ def _main() -> None:
     # run this file again, but with the --on_supercloud flag.
     if not args.on_supercloud:
         _launch_from_local(args.branch, args.user, args.transfer_local_data,
-                           args.supercloud_dir)
+                           args.supercloud_dir, args.config)
         print("Launched experiments.")
     # If we're already on supercloud, launch the experiments.
     else:
@@ -49,7 +49,7 @@ def _main() -> None:
 
 
 def _launch_from_local(branch: str, user: str, transfer_local_data: bool,
-                       supercloud_dir: str) -> None:
+                       supercloud_dir: str, config_file: str) -> None:
     if transfer_local_data:
         # Enter the repo and wipe saved data, approaches and behavior states.
         server_cmds = ["predicate_behavior"]
@@ -68,7 +68,7 @@ def _launch_from_local(branch: str, user: str, transfer_local_data: bool,
         server_cmd_str = "\n".join(server_cmds + ["exit"])
         run_command_with_subprocess(server_cmd_str)
 
-    str_args = " ".join(sys.argv)
+    str_args = " ".join(["scripts/supercloud/launch.py", f"--config {config_file}", f"--user {user}"])
     # Enter the repo.
     server_cmds = ["predicate_behavior"]
     # Prepare the repo.


### PR DESCRIPTION
This PR enables users to run a command involving `--load_atoms` and `--load_data` flags on supercloud. This is enabled by automatically `rync`ing data from local to supercloud and then running the relevant command on supercloud. An example of this is shown below:

```
python scripts/supercloud/launch.py --config behavior_example.yaml --user njk --branch supercloud-load-atoms --transfer_local_data --supercloud_dir /home/gridsan/njk/GitHub/research/predicators_behavior
```