### PR TITLE
Flag for downloading tmp_behavior_states

### DIFF
--- a/scripts/cluster_utils.py
+++ b/scripts/cluster_utils.py
@@ -7,10 +7,7 @@ from typing import Any, Dict, Iterator, List, Tuple
 
 import yaml
 
-SAVE_DIRS = [
-    "results", "logs", "saved_datasets", "saved_approaches",
-    "tmp_behavior_states"
-]
+SAVE_DIRS = ["results", "logs", "saved_datasets", "saved_approaches"]
 SUPERCLOUD_IP = "txe1-login.mit.edu"
 DEFAULT_BRANCH = "master"
 

--- a/scripts/supercloud/download.py
+++ b/scripts/supercloud/download.py
@@ -23,13 +23,17 @@ def _main() -> None:
     parser.add_argument("--dir", required=True, type=str)
     parser.add_argument("--user", required=True, type=str)
     parser.add_argument("--supercloud_dir", default="~/predicators", type=str)
+    parser.add_argument("--download_behavior_states", action="store_true")
     args = parser.parse_args()
     # Create the download directory if it doesn't exist.
     os.makedirs(args.dir, exist_ok=True)
     # Download the results.
     print(f"Downloading results from supercloud for user {args.user}")
     host = f"{args.user}@{SUPERCLOUD_IP}"
-    for save_dir in SAVE_DIRS:
+    save_dirs = SAVE_DIRS
+    if args.download_behavior_states:
+        save_dirs = save_dirs + ["tmp_behavior_states"]
+    for save_dir in save_dirs:
         local_save_dir = os.path.join(args.dir, save_dir)
         os.makedirs(local_save_dir, exist_ok=True)
         cmd = "rsync -avzhe ssh " + \


### PR DESCRIPTION
This PR adds a flag `-download_behavior_states` in `download.py` that can be toggled on to download the `tmp_behavior_states/` folder from supercloud along with the other results.  The default is not downloading `tmp_behavior_states/` because it is likely too large.