### PR TITLE
Changes option_name_to_option to fix failure in `re-shelving_library_books`

### DIFF
--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -111,10 +111,6 @@ class BehaviorEnv(BaseEnv):
         # Everytime we load a new scene in BEHAVIOR we also need to set
         # the valid options again, because there might be new type combos.
         self.set_options()
-        # Create option_name_to_option once
-        self._option_name_to_option = {}
-        for opt in self._options:
-            self._option_name_to_option[opt.name] = opt
 
     def set_options(self) -> None:
         """Sets the underlying options for this particular task using the
@@ -429,8 +425,8 @@ class BehaviorEnv(BaseEnv):
 
     @property
     def task_relevant_types(self) -> Set[Type]:
-        """Gets a subset of types that are relevant to this particular
-        BEHAVIOR problem."""
+        """Gets a subset of types that are relevant to this particular BEHAVIOR
+        problem."""
         # Get the types of all objects in this particular problem.
         curr_problem_type_names = set()
         for ig_obj in self._get_task_relevant_objects():
@@ -453,7 +449,10 @@ class BehaviorEnv(BaseEnv):
         Useful when loading BEHAVIOR trajectories (which will have dummy
         options) and resetting the options used in the trajectories.
         """
-        return self._option_name_to_option
+        option_name_to_option = {}
+        for opt in self._options:
+            option_name_to_option[opt.name] = opt
+        return option_name_to_option
 
     @property
     def action_space(self) -> Box:

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -2759,7 +2759,7 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
     # such that all types could inherit from 'object' we would not need
     # to perform this combinatorial enumeration.
 
-    type_name_to_type = {t.name: t for t in env.types}
+    type_name_to_type = {t.name: t for t in env.task_relevant_types}
     pred_name_to_pred = {p.name: p for p in env.predicates}
 
     def _get_lifted_atom(base_pred_name: str,


### PR DESCRIPTION
Previously, since our `_option_name_to_option` dict was only constructed once at environment creation time for BEHAVIOR envs, it had the wrong options (still not really sure how this was happening, but it did). I changed to compute this dynamically and that ensures that this dictionary is always up-to-date, which allows backchaining to run smoothly on `re-shelving_library_books`.