### PR TITLE
Quicker Samplers for Behavior

### DIFF
--- a/predicators/nsrt_learning/sampler_learning.py
+++ b/predicators/nsrt_learning/sampler_learning.py
@@ -234,9 +234,13 @@ def _create_sampler_data(
             goal = segment.get_goal()
         else:
             goal = None
-        assert all(
-            pre.predicate.holds(state, [var_to_obj[v] for v in pre.variables])
-            for pre in preconditions)
+        # This assertion takes long to both save/load states and run classifers
+        # on every segment, especially in BEHAVIOR.
+        if CFG.env != "behavior":
+            assert all(
+                pre.predicate.holds(state,
+                                    [var_to_obj[v] for v in pre.variables])
+                for pre in preconditions)
         positive_data.append((state, var_to_obj, option, goal))
 
     # Populate all negative data.


### PR DESCRIPTION
We found an assertion that takes long to both save/load states and run classifiers on every segment (especially in BEHAVIOR). So we will no longer run the assertion when learning on behavior.