### PR TITLE
Enables NSRT's to use co-ocurring add effects as add-effects instead of ignore effects

### DIFF
--- a/predicators/envs/behavior.py
+++ b/predicators/envs/behavior.py
@@ -427,8 +427,8 @@ class BehaviorEnv(BaseEnv):
 
     @property
     def task_relevant_types(self) -> Set[Type]:
-        """Gets a subset of types that are relevant to this particular
-        BEHAVIOR problem."""
+        """Gets a subset of types that are relevant to this particular BEHAVIOR
+        problem."""
         # Get the types of all objects in this particular problem.
         curr_problem_type_names = set()
         for ig_obj in self._get_task_relevant_objects():

--- a/predicators/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/predicators/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -346,7 +346,7 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                                             key=str):
             pnads_with_keep_effects = set()
             for pnad in nec_pnad_list:
-                self._compute_pnad_add_effects(pnad)
+                self._compute_extra_add_effects(pnad)
                 self._compute_pnad_delete_effects(pnad)
                 self._compute_pnad_ignore_effects(pnad)
                 pnads_with_keep_effects |= self._get_pnads_with_keep_effects(
@@ -455,7 +455,7 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
         return new_pnad
 
     @staticmethod
-    def _compute_pnad_add_effects(pnad: PartialNSRTAndDatastore) -> None:
+    def _compute_extra_add_effects(pnad: PartialNSRTAndDatastore) -> None:
         """Update the given PNAD to have the add effects include _all_ effects
         that are consistently added in the pnad's datastore (regardless of
         whether they are necessary).

--- a/predicators/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/predicators/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -249,6 +249,9 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                     pnad = self._spawn_new_pnad(segment)
                     param_opt_to_nec_pnads[option.parent].append(pnad)
 
+                    # if "PlaceInside-bucket" in pnad.op.name:
+                    #     import ipdb; ipdb.set_trace()
+
                     # Recompute datastores for ALL PNADs associated with this
                     # option. We need to do this because the new PNAD may now
                     # be a better match for some transition that we previously
@@ -347,6 +350,9 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                                             key=str):
             pnads_with_keep_effects = set()
             for pnad in nec_pnad_list:
+                if "PlaceInside-bucket" in pnad.op.name:
+                    import ipdb; ipdb.set_trace()
+                self._compute_pnad_add_effects(pnad)
                 self._compute_pnad_delete_effects(pnad)
                 self._compute_pnad_ignore_effects(pnad)
                 pnads_with_keep_effects |= self._get_pnads_with_keep_effects(
@@ -454,6 +460,38 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
 
         return new_pnad
 
+    @staticmethod
+    def _compute_pnad_add_effects(pnad: PartialNSRTAndDatastore) -> None:
+        """Update the given PNAD to have the add effects include _all_
+        effects that are consistently added in the pnad's datastore
+        (regardless of whether they are necessary).
+
+        IMPORTANT NOTE: We do not allow creating new variables when we
+        create these add effects. Instead, we filter out add effects that
+        include new variables. What this method is overall doing is just
+        adding in 'unnecessary' add effects that co-occur with necessary
+        add effects that we should have already induced.
+        """
+        op_without_ignore = pnad.op.copy_with(ignore_effects=set())
+        new_add_effects = set()
+        i = 0
+        for segment, var_to_obj in pnad.datastore:
+            objs = tuple(var_to_obj[param] for param in op_without_ignore.parameters)
+            ground_op = op_without_ignore.ground(objs)
+            next_atoms = utils.apply_operator(ground_op, segment.init_atoms)
+            obj_to_var = {o: v for v, o in var_to_obj.items()}
+            unmodeled_add_effects = segment.final_atoms - next_atoms
+            potential_add_effects = {atom for atom in unmodeled_add_effects if all(o in obj_to_var for o in atom.objects)}
+            if len(potential_add_effects) == 0:
+                continue
+            lifted_potential_add_effects = {atom.lift(obj_to_var) for atom in potential_add_effects}
+            if i == 0:
+                new_add_effects = lifted_potential_add_effects
+            else:
+                new_add_effects &= lifted_potential_add_effects
+            i += 1
+        pnad.op = pnad.op.copy_with(add_effects=pnad.op.add_effects | new_add_effects)
+    
     @staticmethod
     def _compute_pnad_delete_effects(pnad: PartialNSRTAndDatastore) -> None:
         """Update the given PNAD to change the delete effects to ones obtained

--- a/predicators/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/predicators/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -248,6 +248,7 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                     nec_pnad_set_changed = True
                     pnad = self._spawn_new_pnad(segment)
                     param_opt_to_nec_pnads[option.parent].append(pnad)
+
                     # Recompute datastores for ALL PNADs associated with this
                     # option. We need to do this because the new PNAD may now
                     # be a better match for some transition that we previously
@@ -468,8 +469,7 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
         """
         op_without_ignore = pnad.op.copy_with(ignore_effects=set())
         new_add_effects = set()
-        i = 0
-        for segment, var_to_obj in pnad.datastore:
+        for i, (segment, var_to_obj) in enumerate(pnad.datastore):
             objs = tuple(var_to_obj[param]
                          for param in op_without_ignore.parameters)
             ground_op = op_without_ignore.ground(objs)
@@ -490,7 +490,6 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                 new_add_effects = lifted_potential_add_effects
             else:
                 new_add_effects &= lifted_potential_add_effects
-            i += 1
 
         pnad.op = pnad.op.copy_with(add_effects=pnad.op.add_effects
                                     | new_add_effects)

--- a/scripts/configs/behavior_example.yaml
+++ b/scripts/configs/behavior_example.yaml
@@ -18,53 +18,11 @@ APPROACHES:
       plan_only_eval: True
       sesame_task_planner: fdopt
 ENVS:
-  collecting-alluminum-cans-Ihlen_1_int:
-    NAME: "behavior"
-    FLAGS:
-      behavior_scene_name: Ihlen_1_int
-      behavior_task_list: "[collecting_aluminum_cans]"
-      behavior_option_model_eval: True
-  throwing-away-leftovers-Ihlen_1_int:
-    NAME: "behavior"
-    FLAGS:
-      behavior_scene_name: Ihlen_1_int
-      behavior_task_list: "[throwing_away_leftovers]"
-      behavior_option_model_eval: True
-  sorting-books-Pomaria_1_int:
-    NAME: "behavior"
-    FLAGS:
-      behavior_scene_name: Pomaria_1_int
-      behavior_task_list: "[sorting_books]"
-      behavior_option_model_eval: True
-  re-shelving-library-books-Pomaria_1_int:
-    NAME: "behavior"
-    FLAGS:
-      behavior_scene_name: Pomaria_1_int
-      behavior_task_list: "[re-shelving_library_books]"
-      behavior_option_model_eval: True
   opening-packages-Pomaria_2_int:
     NAME: "behavior"
     FLAGS:
       behavior_scene_name: Pomaria_2_int
       behavior_task_list: "[opening_packages]"
-      behavior_option_model_eval: True
-  opening-presents-Pomaria_2_int:
-    NAME: "behavior"
-    FLAGS:
-      behavior_scene_name: Pomaria_2_int
-      behavior_task_list: "[opening_presents]"
-      behavior_option_model_eval: True
-  locking-every-window-Merom_1_int:
-    NAME: "behavior"
-    FLAGS:
-      behavior_scene_name: Merom_1_int
-      behavior_task_list: "[locking_every_window]"
-      behavior_option_model_eval: True
-  locking-every-door-Merom_1_int:
-    NAME: "behavior"
-    FLAGS:
-      behavior_scene_name: Merom_1_int
-      behavior_task_list: "[locking_every_door]"
       behavior_option_model_eval: True
 ARGS: {}
 FLAGS:  # general flags

--- a/scripts/configs/behavior_example.yaml
+++ b/scripts/configs/behavior_example.yaml
@@ -18,11 +18,53 @@ APPROACHES:
       plan_only_eval: True
       sesame_task_planner: fdopt
 ENVS:
+  collecting-alluminum-cans-Ihlen_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_scene_name: Ihlen_1_int
+      behavior_task_list: "[collecting_aluminum_cans]"
+      behavior_option_model_eval: True
+  throwing-away-leftovers-Ihlen_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_scene_name: Ihlen_1_int
+      behavior_task_list: "[throwing_away_leftovers]"
+      behavior_option_model_eval: True
+  sorting-books-Pomaria_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_scene_name: Pomaria_1_int
+      behavior_task_list: "[sorting_books]"
+      behavior_option_model_eval: True
+  re-shelving-library-books-Pomaria_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_scene_name: Pomaria_1_int
+      behavior_task_list: "[re-shelving_library_books]"
+      behavior_option_model_eval: True
   opening-packages-Pomaria_2_int:
     NAME: "behavior"
     FLAGS:
       behavior_scene_name: Pomaria_2_int
       behavior_task_list: "[opening_packages]"
+      behavior_option_model_eval: True
+  opening-presents-Pomaria_2_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_scene_name: Pomaria_2_int
+      behavior_task_list: "[opening_presents]"
+      behavior_option_model_eval: True
+  locking-every-window-Merom_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_scene_name: Merom_1_int
+      behavior_task_list: "[locking_every_window]"
+      behavior_option_model_eval: True
+  locking-every-door-Merom_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_scene_name: Merom_1_int
+      behavior_task_list: "[locking_every_door]"
       behavior_option_model_eval: True
 ARGS: {}
 FLAGS:  # general flags

--- a/scripts/configs/behavior_pick_place_learning.yaml
+++ b/scripts/configs/behavior_pick_place_learning.yaml
@@ -1,0 +1,75 @@
+# An example configuration file.
+---
+APPROACHES:
+  my-oracle:  # used in constructing the experiment ID
+    NAME: "oracle"
+    FLAGS:
+      offline_data_planning_timeout: 500.0
+      timeout: 500.0
+      plan_only_eval: True
+      sesame_task_planner: fdopt
+  backchaining:
+    NAME: "nsrt_learning"
+    FLAGS:
+      offline_data_planning_timeout: 500.0
+      timeout: 500.0
+      sampler_learner: neural
+      strips_learner: backchaining
+      plan_only_eval: True
+      sesame_task_planner: fdopt
+ENVS:
+  collecting-alluminum-cans-Ihlen_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_scene_name: Ihlen_1_int
+      behavior_task_list: "[collecting_aluminum_cans]"
+      behavior_option_model_eval: True
+  throwing-away-leftovers-Ihlen_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_scene_name: Ihlen_1_int
+      behavior_task_list: "[throwing_away_leftovers]"
+      behavior_option_model_eval: True
+  sorting-books-Pomaria_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_scene_name: Pomaria_1_int
+      behavior_task_list: "[sorting_books]"
+      behavior_option_model_eval: True
+  re-shelving-library-books-Pomaria_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_scene_name: Pomaria_1_int
+      behavior_task_list: "[re-shelving_library_books]"
+      behavior_option_model_eval: True
+  opening-packages-Pomaria_2_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_scene_name: Pomaria_2_int
+      behavior_task_list: "[opening_packages]"
+      behavior_option_model_eval: True
+  opening-presents-Pomaria_2_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_scene_name: Pomaria_2_int
+      behavior_task_list: "[opening_presents]"
+      behavior_option_model_eval: True
+  locking-every-window-Merom_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_scene_name: Merom_1_int
+      behavior_task_list: "[locking_every_window]"
+      behavior_option_model_eval: True
+  locking-every-door-Merom_1_int:
+    NAME: "behavior"
+    FLAGS:
+      behavior_scene_name: Merom_1_int
+      behavior_task_list: "[locking_every_door]"
+      behavior_option_model_eval: True
+ARGS: {}
+FLAGS:  # general flags
+  num_train_tasks: 10
+  num_test_tasks: 10
+START_SEED: 456
+NUM_SEEDS: 3
+USE_GPU: True

--- a/scripts/configs/behavior_pick_place_learning.yaml
+++ b/scripts/configs/behavior_pick_place_learning.yaml
@@ -18,7 +18,7 @@ APPROACHES:
       plan_only_eval: True
       sesame_task_planner: fdopt
 ENVS:
-  collecting-alluminum-cans-Ihlen_1_int:
+  collecting-aluminum-cans-Ihlen_1_int:
     NAME: "behavior"
     FLAGS:
       behavior_scene_name: Ihlen_1_int

--- a/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
@@ -1378,9 +1378,9 @@ def test_backchaining_segment_not_in_datastore():
         """STRIPS-Pick:
     Parameters: []
     Preconditions: [C(), E()]
-    Add Effects: [B()]
+    Add Effects: [A(), B(), D()]
     Delete Effects: []
-    Ignore Effects: [A, D]
+    Ignore Effects: []
     Option Spec: Pick()""", """STRIPS-Pick:
     Parameters: []
     Preconditions: [B(), D(), E()]
@@ -1390,15 +1390,15 @@ def test_backchaining_segment_not_in_datastore():
     Option Spec: Pick()""", """STRIPS-Pick:
     Parameters: []
     Preconditions: [A(), C(), D()]
-    Add Effects: [A(), B(), D()]
+    Add Effects: [A(), B(), D(), E()]
     Delete Effects: [C()]
-    Ignore Effects: [E]
+    Ignore Effects: []
     Option Spec: Pick()""", """STRIPS-Pick:
     Parameters: []
     Preconditions: [A(), D()]
-    Add Effects: [A(), B()]
+    Add Effects: [A(), B(), E()]
     Delete Effects: [D()]
-    Ignore Effects: [E]
+    Ignore Effects: []
     Option Spec: Pick()""", """STRIPS-Pick:
     Parameters: []
     Preconditions: [A(), B(), D()]
@@ -1407,9 +1407,6 @@ def test_backchaining_segment_not_in_datastore():
     Ignore Effects: []
     Option Spec: Pick()"""
     ]
-
-    import ipdb
-    ipdb.set_trace()
     for pnad in learned_pnads:
         # Rename the output PNADs to standardize naming
         # and make comparison easier.

--- a/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
@@ -1302,6 +1302,8 @@ def test_multi_pass_backchaining(val):
     Option Spec: Place()"""
         ]
 
+    import ipdb; ipdb.set_trace()
+
     for pnad in learned_pnads:
         # Rename the output PNADs to standardize naming
         # and make comparison easier.
@@ -1407,6 +1409,8 @@ def test_backchaining_segment_not_in_datastore():
     Ignore Effects: []
     Option Spec: Pick()"""
     ]
+
+    import ipdb; ipdb.set_trace()
     for pnad in learned_pnads:
         # Rename the output PNADs to standardize naming
         # and make comparison easier.

--- a/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
@@ -1262,9 +1262,9 @@ def test_multi_pass_backchaining(val):
             """STRIPS-Pick:
     Parameters: []
     Preconditions: [A()]
-    Add Effects: [B()]
+    Add Effects: [B(), C()]
     Delete Effects: []
-    Ignore Effects: [C]
+    Ignore Effects: []
     Option Spec: Pick()""", """STRIPS-Place:
     Parameters: []
     Preconditions: [A(), B()]
@@ -1274,9 +1274,9 @@ def test_multi_pass_backchaining(val):
     Option Spec: Place()""", """STRIPS-Place:
     Parameters: []
     Preconditions: [A(), B()]
-    Add Effects: [C(), D()]
+    Add Effects: [C(), D(), E()]
     Delete Effects: [B()]
-    Ignore Effects: [E]
+    Ignore Effects: []
     Option Spec: Place()"""
         ]
     else:
@@ -1290,9 +1290,9 @@ def test_multi_pass_backchaining(val):
     Option Spec: Pick()""", """STRIPS-Place:
     Parameters: []
     Preconditions: [A(), B(), C()]
-    Add Effects: [D()]
+    Add Effects: [D(), E()]
     Delete Effects: [B()]
-    Ignore Effects: [E]
+    Ignore Effects: []
     Option Spec: Place()""", """STRIPS-Place:
     Parameters: []
     Preconditions: [A(), B(), E()]
@@ -1301,8 +1301,6 @@ def test_multi_pass_backchaining(val):
     Ignore Effects: []
     Option Spec: Place()"""
         ]
-
-    import ipdb; ipdb.set_trace()
 
     for pnad in learned_pnads:
         # Rename the output PNADs to standardize naming
@@ -1410,7 +1408,8 @@ def test_backchaining_segment_not_in_datastore():
     Option Spec: Pick()"""
     ]
 
-    import ipdb; ipdb.set_trace()
+    import ipdb
+    ipdb.set_trace()
     for pnad in learned_pnads:
         # Rename the output PNADs to standardize naming
         # and make comparison easier.


### PR DESCRIPTION
Previously, we would treat co-occurring but unnecessary add effects (e.g. `reachable-pop` for `collecting_aluminum_cans`) as ignore effects, which can cause use to learn hyper-complex operators. This PR changes that, which enables us to recover ground truth NSRT's from 10 demos on the `collecting_aluminum_cans` task.