### PR TITLE
Remove Pomaria_1_int from `throwing_away_leftovers`

### DIFF
--- a/predicators/behavior_utils/task_to_preselected_scenes.json
+++ b/predicators/behavior_utils/task_to_preselected_scenes.json
@@ -671,7 +671,6 @@
     ],
     "throwing_away_leftovers": [
         "Ihlen_1_int",
-        "Pomaria_1_int",
         "Wainscott_0_int"
     ],
     "unpacking_suitcase": [


### PR DESCRIPTION
We are removing Pomaria_1_int from `throwing_away_leftovers` houses because the trash can has no opening.